### PR TITLE
Add Supabase Leaderboard Integration with Time-Based Tiebreaking

### DIFF
--- a/src/controllers/GameStatsController.ts
+++ b/src/controllers/GameStatsController.ts
@@ -128,6 +128,10 @@ export class GameStatsController {
 		this.points = 0;
 	}
 
+	public getPoints(): number {
+		return this.points;
+	}
+
 	public attachHudStage(stage: Konva.Stage): void {
 		this.layer = new Konva.Layer();
 		stage.add(this.layer);

--- a/src/controllers/ResultScreenController.ts
+++ b/src/controllers/ResultScreenController.ts
@@ -17,6 +17,7 @@ import { ResultScreenView } from "../views/ResultScreenView";
 import { ScreenSwitcher, Screens } from "../utils/types";
 import { LeaderboardView } from "../views/LeaderboardView";
 import { LeaderboardEntry, Player } from "../models/LeaderboardModel";
+import { LeaderboardService } from '../services/LeaderboardService';
 
 export class ResultScreenController {
     private view: ResultScreenView;
@@ -30,24 +31,33 @@ export class ResultScreenController {
         this.view = new ResultScreenView(this.handleRestart, container);
         this.leaderboard = new LeaderboardView();
         this.switcher = switcher;
-
+    
         this.ro = new ResizeObserver(this.handleResize);
         this.ro.observe(document.getElementById(container)!);
         
-        // mock a leaderboard entry for demo purposes
-        let mockPlayer: Player = {
-            id: 42,
-            name: "hal"
+        // Attach leaderboard view to layer
+        this.view.getLayer().add(this.leaderboard.getGroup());
+        
+        // Load real leaderboard data
+        this.loadLeaderboard();
+    }
+    
+    // Add method to load and display leaderboard
+    private async loadLeaderboard(): Promise<void> {
+        const entries = await LeaderboardService.getTopScores(5);
+        
+        if (entries.length > 0) {
+            this.leaderboard.draw(entries);
+        } else {
+            // Show empty state if no scores yet
+            console.log('No scores yet. leaderboard is empty');
+            this.leaderboard.draw([]);
         }
-        let mockEntry: LeaderboardEntry = {
-            score: 100,
-            player: mockPlayer,
-            timestamp: "now"
-        }
-
-        // attach leaderboard to results screen directly for demo purposes, maybe will change later
-        this.leaderboard.draw([mockEntry])
-        this.view.getLayer().add(this.leaderboard.getGroup())
+    }
+    
+    // Add public method to refresh leaderboard when screen is shown
+    public refreshLeaderboard(): void {
+        this.loadLeaderboard();
     }
 
     handleRestart = () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -277,6 +277,7 @@ class Application extends ScreenSwitcher {
                 this.menu.getView().show();
                 break;
             case Screens.Leaderboard:
+                this.leaderboard.refreshLeaderboard();
                 this.leaderboard.getView().show();
                 break;
             default: 

--- a/src/services/LeaderboardService.ts
+++ b/src/services/LeaderboardService.ts
@@ -1,0 +1,92 @@
+// src/services/LeaderboardService.ts
+import { supabase } from '../supabaseClient';
+import type { LeaderboardEntry, Player } from '../models/LeaderboardModel';
+
+type GameResultRow = {
+    id: number;
+    player_name: string;
+    score: number;
+    played_at: string;
+    game_duration_seconds: number | null;
+};
+
+export class LeaderboardService {
+    /**
+     * Save a new game result to the database
+     */
+    static async saveScore(
+        playerName: string, 
+        score: number, 
+        gameDurationSeconds: number | null
+    ): Promise<boolean> {
+        if (!supabase) {
+            console.error('[LeaderboardService] Supabase not initialized');
+            return false;
+        }
+    
+        try {
+            const { error } = await supabase
+                .from('game_results')
+                .insert({
+                    player_name: playerName,
+                    score: score,
+                    played_at: new Date().toISOString(),
+                    game_duration_seconds: gameDurationSeconds
+                });
+    
+            if (error) {
+                console.error('[LeaderboardService] Error saving score:', error);
+                return false;
+            }
+    
+            console.log(`[LeaderboardService] Score saved: ${playerName} - ${score} (${gameDurationSeconds}s)`);
+            return true;
+        } catch (err) {
+            console.error('[LeaderboardService] Unexpected error:', err);
+            return false;
+        }
+    }
+
+    /**
+     * Fetch top scores from the database
+     */
+    static async getTopScores(limit: number = 10): Promise<LeaderboardEntry[]> {
+        if (!supabase) {
+            console.error('[LeaderboardService] Supabase not initialized');
+            return [];
+        }
+    
+        try {
+            const { data, error } = await supabase
+                .from('game_results')
+                .select('id, player_name, score, played_at, game_duration_seconds')
+                .order('score', { ascending: false })
+                .order('game_duration_seconds', { ascending: true }) // Faster time wins ties
+                .limit(limit);
+    
+            if (error) {
+                console.error('[LeaderboardService] Error fetching scores:', error);
+                return [];
+            }
+    
+            return (data as GameResultRow[] || []).map((row: GameResultRow) => {
+                const duration = row.game_duration_seconds;
+                const minutes = duration ? Math.floor(duration / 60) : 0;
+                const seconds = duration ? duration % 60 : 0;
+                const timeStr = duration ? `${minutes}:${seconds.toString().padStart(2, '0')}` : '--:--';
+                
+                return {
+                    score: row.score,
+                    player: {
+                        id: row.id,
+                        name: row.player_name
+                    },
+                    timestamp: timeStr // Show duration instead of date
+                };
+            });
+        } catch (err) {
+            console.error('[LeaderboardService] Unexpected error:', err);
+            return [];
+        }
+    }
+}

--- a/src/views/LeaderboardView.ts
+++ b/src/views/LeaderboardView.ts
@@ -18,12 +18,12 @@ import { getDims } from "../utils/ViewUtils";
 const TEXT_COLOR = "#000000ff";
 
 // title constants
-const TITLE_Y = 100; // Y position of the title text
+const TITLE_Y = 80; // Y position of the title text
 
 // entry constants
-const START_Y = TITLE_Y + 80; // Y position of first entry
-const ENTRY_SPACING = 40; // vertical spacing between entries
-const ENTRY_FONTSIZE = 32;
+const START_Y = TITLE_Y + 100; // Y position of first entry
+const ENTRY_SPACING = 45; // vertical spacing between entries
+const ENTRY_FONTSIZE = 35;
 const ENTRY_COLOR_1ST = "#d4a91aff";
 const ENTRY_COLOR_2ND = "#686868ff";
 const ENTRY_COLOR_3RD = "#9d6226ff";
@@ -49,7 +49,7 @@ export class LeaderboardView {
 			x: w / 2, // TEMP EDIT: "w" used to be STAGE_WIDTH
 			y: TITLE_Y,
 			text: "High Scores",
-			fontSize: 48,
+			fontSize: 42,
 			fill: TEXT_COLOR,
 			align: "center",
 		});
@@ -76,7 +76,7 @@ export class LeaderboardView {
             const text = new Konva.Text({
                 x: w / 2, // TEMP EDIT: "w" used to be STAGE_WIDTH
                 y: y,
-                text: `${index + 1}. ${entry.player.name} - ${entry.score}`,
+                text: `${index + 1}. ${entry.player.name} - ${entry.score} pts (${entry.timestamp})`,
                 fontSize: ENTRY_FONTSIZE,
                 fill: fillColor,
                 align: "center",

--- a/src/views/ResultScreenView.ts
+++ b/src/views/ResultScreenView.ts
@@ -40,7 +40,7 @@ export class ResultScreenView {
         this.restartGroup = new Konva.Group({});
         this.id = id;
         
-        const restartLabel = simpleLabelFactory(w / 2, h / 4, "Restart Game", restartHandler);
+        const restartLabel = simpleLabelFactory(w / 2, h - 450, "Restart Game", restartHandler);
         this.restartGroup.add(restartLabel);
 
         this.layer.add(this.restartGroup);


### PR DESCRIPTION
This PR integrates a persistent leaderboard system using Supabase that tracks player scores and game completion times. Players can now view the top 5 performers directly from the welcome screen.

Changes Made

Backend/Database

* Created game_results table in Supabase with columns: id, player_name, score, game_duration_seconds, played_at, created_at
* Implemented Row Level Security (RLS) policies:

  * Public read access for viewing leaderboard
  * Public insert for submitting scores
  * Blocked updates/deletes to prevent cheating

New Files

* src/services/LeaderboardService.ts: Service layer for all Supabase operations

  * saveScore(): Saves player name, score, and game duration
  * getTopScores(): Fetches top 5 scores with proper sorting

Modified Files

* QuizManager.ts:

  * Added game start time tracking
  * Calculate game duration on completion
  * Save scores to database before showing leaderboard
  * Added getScore() and getName() getters

* GameStatsController.ts:

  * Added getPoints() method for score retrieval

* ResultScreenController.ts:

  * Removed mock data
  * Added loadLeaderboard() to fetch real data from Supabase
  * Added refreshLeaderboard() to update data when screen is shown

* LeaderboardView.ts:

  * Updated display format to show: "Rank. Name - Score pts (Time)"
  * Adjusted spacing and font sizes for top 5 entries
  * Time displayed in MM:SS format