### PR TITLE
feat: add max mistakes slider to options screen

### DIFF
--- a/src/controllers/QuestionToggleController.test.ts
+++ b/src/controllers/QuestionToggleController.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect,vi } from "vitest";
 import { QuestionToggleController } from "./QuestionToggleController";
 import Konva from "konva";
+import { ConfigurationModel } from "../models/ConfigurationModel";
+import { GameStatsController } from "./GameStatsController";
+import { UIController } from "./UIController";
+
 
 describe("question toggle controller", () => {
     const mockEl = document.createElement("div");
@@ -8,12 +12,27 @@ describe("question toggle controller", () => {
     document.body.appendChild(mockEl);
 
     const stage = new Konva.Stage({
-        container: mockEl,
+        container: mockEl.id,
         width: 400,
         height: 300,
     });
+    const config = new ConfigurationModel(); 
+    const statsMock = {
+        updateMaxErrors: vi.fn(),
+    } as unknown as GameStatsController;
 
-    let QTC = new QuestionToggleController(new Konva.Stage({container: mockEl.id}), "main-menu-container");
+    const uiMock = {
+        updateMaxErrors: vi.fn(),
+    } as unknown as UIController;
+
+    let QTC = new QuestionToggleController(
+        stage,
+        "main-menu-container",
+        config,
+        statsMock,
+        uiMock,
+        () => {} // onBackCallback
+    );
 
     it("should initialize a view and model", () => {
         expect(QTC.getView()).toBeDefined();

--- a/src/controllers/QuestionToggleController.ts
+++ b/src/controllers/QuestionToggleController.ts
@@ -25,24 +25,53 @@ import { QuestionToggleView, Toggles } from "../views/QuestionToggleView";
 import { QuestionBankModel } from "../models/QuestionBankModel";
 import { PopUpView } from "../views/PopUpView";
 import Konva from "konva";
+import { ConfigurationModel } from "../models/ConfigurationModel";
+import { GameStatsController } from "./GameStatsController";
+import { UIController } from "./UIController";
+
 
 export class QuestionToggleController {
     private model: QuestionBankModel;
     private view: QuestionToggleView;
     private currentToggled: Toggles;
     private popup: PopUpView;
-    private onBackCallback?: () => void
+    private onBackCallback?: () => void;
 
-    constructor(stage: Konva.Stage, id: string, onBackCallback?: () => void) {
+    
+
+    constructor(
+        stage: Konva.Stage, 
+        id: string,    
+        private config: ConfigurationModel,
+        private stats: GameStatsController,
+        private ui: UIController, 
+        onBackCallback?: () => void, 
+    ) {
         this.onBackCallback = onBackCallback;
+
         this.currentToggled = { 
             "capitalQuestions": false, 
             "flowerQuestions": false, 
             "abbreviationQuestions": false,
             "dateQuestions": false 
         }
-        this.view = new QuestionToggleView(this.handleBack, this.toggleOption, this.saveOptions, stage, id);
+
         this.model = new QuestionBankModel();
+
+        this.view = new QuestionToggleView(
+            this.handleBack, 
+            this.toggleOption, 
+            this.saveOptions, 
+            stage, 
+            id,
+            this.config.getMaxErrors(),   
+            (value: number) => { 
+                this.config.setMaxErrors(value);
+                this.stats.updateMaxErrors(value);
+                this.ui.updateMaxErrors(value);
+            }
+        );
+
         this.popup = new PopUpView(this.view.getLayer(), "Please enable at least one question type.");
     }
 
@@ -67,7 +96,8 @@ export class QuestionToggleController {
 
     // sends the model the selected options to save
     saveOptions = () => {
-        let options: string[] = Object.keys(this.currentToggled).filter((x) => this.currentToggled[x]);
+        let options: string[] = Object.keys(this.currentToggled)
+            .filter((x) => this.currentToggled[x]);
         if (options.length === 0) {
             this.popup.show()
             setTimeout(() => {this.popup.hide()}, 3000)

--- a/src/controllers/QuizManager.test.ts
+++ b/src/controllers/QuizManager.test.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ScreenSwitcher } from "../utils/types";
-import { QuizManager } from "./QuizManager"
+import { QuizManager } from "./QuizManager";
 import { TimerController } from "./TimerController";
 import { TimerModel } from "../models/TimerModel";
-import TimerViewCorner from "../views/TimerDisplayView"
+import TimerViewCorner from "../views/TimerDisplayView";
 import { QuestionBankModel } from "../models/QuestionBankModel";
 import { GameStatsController } from "./GameStatsController";
 import { UIController } from "./UIController";
 import { MapController } from "./MapController";
-import { USState } from "../models/State";
+import { USState, StateStatus } from "../models/State";
 import { StateStore } from "../models/StateStore";
-import { StateStatus } from "../models/State";
-import Konva from "konva"
+import Konva from "konva";
+import { ConfigurationModel } from "../models/ConfigurationModel";
 
 // Mock ResizeObserver meant for Konva
 class ResizeObserverMock {
@@ -19,99 +19,101 @@ class ResizeObserverMock {
   unobserve = vi.fn();
   disconnect = vi.fn();
 }
-vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+vi.stubGlobal("ResizeObserver", ResizeObserverMock);
 
 // Seed data
 const seed: USState[] = Object.keys({
-    WA:1, OR:1, CA:1, ID:1, NV:1, AZ:1, UT:1, CO:1, NM:1,
-    MT:1, WY:1, ND:1, SD:1, NE:1, KS:1, OK:1, TX:1,
-    MN:1, IA:1, MO:1, WI:1, IL:1, AR:1, LA:1,
-    MI:1, IN:1, KY:1, TN:1, MS:1, AL:1, GA:1, FL:1, SC:1, NC:1,
-    VA:1, WV:1, OH:1, PA:1, NY:1, NJ:1, MD:1, DE:1, CT:1, RI:1, MA:1, VT:1, NH:1, ME:1, DC:1,
-    AK:1, HI:1
-}).map(code => ({
-    code,
-    name: code,
-    status: StateStatus.NotStarted
+  WA: 1, OR: 1, CA: 1, ID: 1, NV: 1, AZ: 1, UT: 1, CO: 1, NM: 1,
+  MT: 1, WY: 1, ND: 1, SD: 1, NE: 1, KS: 1, OK: 1, TX: 1,
+  MN: 1, IA: 1, MO: 1, WI: 1, IL: 1, AR: 1, LA: 1,
+  MI: 1, IN: 1, KY: 1, TN: 1, MS: 1, AL: 1, GA: 1, FL: 1, SC: 1, NC: 1,
+  VA: 1, WV: 1, OH: 1, PA: 1, NY: 1, NJ: 1, MD: 1, DE: 1, CT: 1, RI: 1, MA: 1, VT: 1, NH: 1, ME: 1, DC: 1,
+  AK: 1, HI: 1,
+}).map((code) => ({
+  code,
+  name: code,
+  status: StateStatus.NotStarted,
 }));
 
-describe("main screen controller", () => {
-    // Declare variables at the top level
-    let stage: Konva.Stage;
-    let switcher: ScreenSwitcher;
-    let quiz: QuizManager;
-    let store: StateStore;
-    let bank: QuestionBankModel;
-    let map: MapController;
-    let stats: GameStatsController;
-    let timer: TimerController;
-    let ui: UIController;
+describe("quiz manager", () => {
+  let stage: Konva.Stage;
+  let switcher: ScreenSwitcher;
+  let quiz: QuizManager;
+  let store: StateStore;
+  let bank: QuestionBankModel;
+  let map: MapController;
+  let stats: GameStatsController;
+  let timer: TimerController;
+  let ui: UIController;
+  let config: ConfigurationModel;
 
-    beforeEach(() => {
-        // 1. Setup Fake Timers
-        vi.useFakeTimers();
+  beforeEach(() => {
+    // 1. Setup Fake Timers
+    vi.useFakeTimers();
 
-        // 2. Create fresh DOM elements
-        document.body.innerHTML = '';
-        const mockEl = document.createElement("div");
-        const inputEl = document.createElement("input");
-        mockEl.id = "main-menu-container";
-        inputEl.id = "nameInput";
-        document.body.appendChild(mockEl);
-        document.body.appendChild(inputEl);
+    // 2. Create fresh DOM elements
+    document.body.innerHTML = "";
+    const mockEl = document.createElement("div");
+    mockEl.id = "map-root"; 
+    document.body.appendChild(mockEl);
 
-        // 3. Initialize Instances
-        stage = new Konva.Stage({
-            container: mockEl, 
-            width: 800,
-            height: 600,
-        });
+    // 3. Basic models / controllers
+    config = new ConfigurationModel();
 
-        switcher = new ScreenSwitcher();
-        quiz = new QuizManager(switcher);
-        store = new StateStore(seed);
-        bank = new QuestionBankModel();
-        bank.setQuestions(["capitalQuestions"]);
-        
-        map = new MapController(
-            store,
-            { openQuestion: (q: any) => {} }
-        );
-        
-        stats = new GameStatsController(map);
-        timer = new TimerController(new TimerModel(300), new TimerViewCorner(stage), switcher);
-        ui = new UIController(map, stats, quiz);
+    stage = new Konva.Stage({
+      container: mockEl,
+      width: 800,
+      height: 600,
     });
 
-    afterEach(() => {
-        // 4. CRITICAL: Destroy stage to stop Konva from trying to draw on null canvas
-        if (stage) {
-            stage.destroy();
-        }
-        // 5. Clear timers
-        vi.clearAllTimers();
-        vi.useRealTimers();
+    switcher = new ScreenSwitcher();
+
+    quiz = new QuizManager(switcher);
+
+    store = new StateStore(seed);
+    bank = new QuestionBankModel();
+    bank.setQuestions(["capitalQuestions"]);
+
+    map = new MapController(store, {
+      openQuestion: (_q: any) => {},
     });
 
-    it("should start unitialized", () => {
-        expect(quiz.getStatus()).toBeFalsy();
-        expect(quiz.getNextQuestion()).toBeNull();
-        expect(quiz.getIncorrectAnswers("California", "capitalQuestions")).toBeNull();
-        expect(quiz.getQuestionBank()).toBeNull();
-    })
+    stats = new GameStatsController(map, config);
+    timer = new TimerController(new TimerModel(300), new TimerViewCorner(stage), switcher);
 
-    it("should be initialized after calling init", () => {
-        quiz.init(bank, stats, ui, timer, map);
-        expect(quiz.getStatus()).toBeTruthy();
-    })
+    // UIController: (map, stats, quiz)
+    ui = new UIController(map, stats, quiz);
+  });
 
-    it("should be able to return questions", () => {
-        // Fix here: Init the quiz so it has data
-        quiz.init(bank, stats, ui, timer, map);
+  afterEach(() => {
+    if (stage) {
+      stage.destroy();
+    }
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
 
-        expect(quiz.getNextQuestion() === null).toBeFalsy();
-        expect(quiz.getIncorrectAnswers("California", "capitalQuestions") === null).toBeFalsy();
-        expect(quiz.getIncorrectAnswers("", "")).toBeNull();
-        expect(quiz.getQuestionBank() === null).toBeFalsy();
-    })
+  it("should start uninitialized", () => {
+    expect(quiz.getStatus()).toBeFalsy();
+    expect(quiz.getNextQuestion()).toBeNull();
+    expect(quiz.getIncorrectAnswers("California", "capitalQuestions")).toBeNull();
+    expect(quiz.getQuestionBank()).toBeNull();
+  });
+
+  it("should be initialized after calling init", () => {
+    quiz.init(bank, stats, ui, timer, map);
+    expect(quiz.getStatus()).toBeTruthy();
+  });
+
+  it("should be able to return questions", () => {
+    // Init the quiz so it has data
+    quiz.init(bank, stats, ui, timer, map);
+
+    expect(quiz.getNextQuestion() === null).toBeFalsy();
+    expect(
+      quiz.getIncorrectAnswers("California", "capitalQuestions") === null
+    ).toBeFalsy();
+    expect(quiz.getIncorrectAnswers("", "")).toBeNull();
+    expect(quiz.getQuestionBank() === null).toBeFalsy();
+  });
 });

--- a/src/controllers/ResultScreenController.test.ts
+++ b/src/controllers/ResultScreenController.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { ResultScreenController } from "./ResultScreenController";
 import { ScreenSwitcher } from "../utils/types";
 import { QuizManager } from "./QuizManager"
+import { ConfigurationModel } from "../models/ConfigurationModel";
 
 class ResizeObserverMock {
   observe = vi.fn();
@@ -13,7 +14,9 @@ vi.stubGlobal('ResizeObserver', ResizeObserverMock);
 
 describe("result screen controller", () => {
     let switcher: ScreenSwitcher = new ScreenSwitcher();
+    const config = new ConfigurationModel(); 
     let quiz: QuizManager = new QuizManager(switcher);
+
     const mockEl = document.createElement("div");
     mockEl.id = "main-menu-container";
     document.body.appendChild(mockEl);

--- a/src/controllers/TimerController.ts
+++ b/src/controllers/TimerController.ts
@@ -15,7 +15,7 @@ export class TimerController {
     console.log("TimerController: Starting timer");
     this.model.startTimer(
       (s) => {
-        console.log("TimerController: Tick - seconds remaining:", s);
+        // console.log("TimerController: Tick - seconds remaining:", s);
         this.view.updateTimer(s);
       },
       () => {

--- a/src/controllers/UIController.ts
+++ b/src/controllers/UIController.ts
@@ -75,7 +75,7 @@ export class UIController {
 
 		this.card.getLayer().visible(false);
 		this.stage.add(this.card.getLayer());
-		this.card.resize(); // let question resize to fit the stage size.
+
 
 		this.overlay.moveToTop();
 		this.card.getLayer().moveToTop();
@@ -88,6 +88,7 @@ export class UIController {
 		this.fireworks = new FireworksView(this.fxLayer);
 
 		this.stage.draw();
+		this.card.resize(); // let question resize to fit the stage size.
 	}
 
 	// for now, go to a random question. later (next sprint?), i think i'll add an optional parameter for manual vs. auto mode
@@ -115,19 +116,23 @@ export class UIController {
 	}
 
 	public answerResponse(correct: boolean) {
-		this.feedback?.show(correct, this.card);
-		if (!correct) {
-			this.card.highlightCorrect();
-		}
+		let deltaPoints = 0;
 
 		if (this.mapController && this.currentState && this.mapController.getSelectedState) {
-			const currentState = this.mapController.getSelectedState?.(); // use for diff mode later?
+			const currentState = this.mapController.getSelectedState?.(); 
 			if (correct) {
-				this.statsController.onCorrect(this.currentState.code);
+
+				deltaPoints = this.statsController.onCorrect(this.currentState.code);
 			} else {
 				this.statsController.onIncorrect(this.currentState.code);
 			}
-		}			
+		}
+
+		this.feedback?.show(correct, this.card, deltaPoints);
+
+		if (!correct) {
+			this.card.highlightCorrect();
+		}
 
 		// New notice the car action: ture-get star, false get roadblocks
 		if (this.roadTripDashboard) {
@@ -145,6 +150,14 @@ export class UIController {
 	// public API called when a state is clicked or quiz begins
 	public openQuestion(q: any) {
 		if (!this.overlay || !this.card) return;
+		const container = this.stage.container();
+		const rect = container.getBoundingClientRect();
+		if (rect.width && rect.height) {
+			this.stage.width(rect.width);
+			this.stage.height(rect.height);
+		}
+
+		this.card.resize();
 
 		this.mapController.setInteractive(false);
 		if (q) {
@@ -189,6 +202,11 @@ export class UIController {
 	public attachRoadTripDashboard(view: RoadTripDashboardView): void {
         this.roadTripDashboard = view;
     }
+	public updateMaxErrors(maxErrors: number): void {
+ 	   this.roadTripDashboard?.setMaxHits(maxErrors);
+  	}
+
+
 	public resetRoadTripHud(): void {
  	   this.roadTripDashboard?.reset();
  	}

--- a/src/controllers/WelcomeScreenController.test.ts
+++ b/src/controllers/WelcomeScreenController.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi } from "vitest";
 import { WelcomeScreenController } from "./WelcomeScreenController";
 import { ScreenSwitcher } from "../utils/types";
 import { QuizManager } from "./QuizManager"
+import { ConfigurationModel } from "../models/ConfigurationModel";
+import { UIController } from "./UIController";
+import { MapController } from "./MapController";
+import { GameStatsController } from "./GameStatsController";
 
 class ResizeObserverMock {
   observe = vi.fn();
@@ -14,13 +18,38 @@ vi.stubGlobal('ResizeObserver', ResizeObserverMock);
 describe("main screen controller", () => {
     const mockEl = document.createElement("div");
     const inputEl = document.createElement("input");
+    const config = new ConfigurationModel();
+
     mockEl.id = "main-menu-container";
     inputEl.id = "nameInput";
+
     document.body.appendChild(mockEl);
     document.body.appendChild(inputEl);
-    let switcher: ScreenSwitcher = new ScreenSwitcher();
-    let quiz: QuizManager = new QuizManager(switcher);
-    let WSC = new WelcomeScreenController("main-menu-container", quiz);
+    const switcher: ScreenSwitcher = new ScreenSwitcher();
+    const quiz: QuizManager = new QuizManager(switcher);
+    
+    const dummyMap = {
+      getStore: () => ({
+        getAll: () => [],
+      }),
+      getStage: () => null,
+    } as unknown as MapController;
+
+    const ui = {
+      updateMaxErrors: vi.fn(),
+      attachRoadTripDashboard: vi.fn(),
+      resetRoadTripHud: vi.fn(),
+    } as unknown as UIController;
+
+    const stats = new GameStatsController(dummyMap, config);
+
+    const WSC = new WelcomeScreenController(
+    "main-menu-container",
+      quiz,
+      config,
+      stats,
+      ui
+    );
 
     it("should initialize a view and togglecontroller", () => {
         expect(WSC.getView()).toBeDefined();

--- a/src/controllers/WelcomeScreenController.test.ts
+++ b/src/controllers/WelcomeScreenController.test.ts
@@ -6,6 +6,7 @@ import { ConfigurationModel } from "../models/ConfigurationModel";
 import { UIController } from "./UIController";
 import { MapController } from "./MapController";
 import { GameStatsController } from "./GameStatsController";
+import Konva from "konva";
 
 class ResizeObserverMock {
   observe = vi.fn();
@@ -14,6 +15,12 @@ class ResizeObserverMock {
 }
 
 vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+
+const rectDrawSceneSpy = vi
+  .spyOn(Konva.Rect.prototype as any, "drawScene")
+  .mockImplementation(() => {
+    return;
+  });
 
 describe("main screen controller", () => {
     const mockEl = document.createElement("div");
@@ -63,7 +70,7 @@ describe("main screen controller", () => {
       expect(Object.keys(WSC.getToggler().getModel().getQuestions()).length === 1).toBeTruthy()
     })
 
-/*     it("should swap when handleInfo() is called", () => {
+    it("should swap when handleInfo() is called", () => {
       WSC.handleInfo();
       expect(WSC.getView().getInput().style.display).toEqual("none")
     })
@@ -77,5 +84,5 @@ describe("main screen controller", () => {
       WSC.handleOptions();
       expect(WSC.getView().getInput().style.display).toEqual("none")
       expect(WSC.getToggler().getView().getLayer()["attrs"]["visible"]).toBeTruthy()
-    }) */
+    }) 
 })

--- a/src/controllers/WelcomeScreenController.test.ts
+++ b/src/controllers/WelcomeScreenController.test.ts
@@ -63,7 +63,7 @@ describe("main screen controller", () => {
       expect(Object.keys(WSC.getToggler().getModel().getQuestions()).length === 1).toBeTruthy()
     })
 
-    it("should swap when handleInfo() is called", () => {
+/*     it("should swap when handleInfo() is called", () => {
       WSC.handleInfo();
       expect(WSC.getView().getInput().style.display).toEqual("none")
     })
@@ -77,5 +77,5 @@ describe("main screen controller", () => {
       WSC.handleOptions();
       expect(WSC.getView().getInput().style.display).toEqual("none")
       expect(WSC.getToggler().getView().getLayer()["attrs"]["visible"]).toBeTruthy()
-    })
+    }) */
 })

--- a/src/controllers/WelcomeScreenController.ts
+++ b/src/controllers/WelcomeScreenController.ts
@@ -28,6 +28,10 @@ import { PopUpView } from "../views/PopUpView";
 import { getDims } from "../utils/ViewUtils";
 import { QuizManager } from "./QuizManager";
 import { sanitize } from "../utils/NameValidator";
+import { ConfigurationModel } from "../models/ConfigurationModel";
+import { GameStatsController } from "../controllers/GameStatsController";
+import { UIController } from "../controllers/UIController";
+
 
 export class WelcomeScreenController {
     private view: WelcomeScreenView;
@@ -37,10 +41,31 @@ export class WelcomeScreenController {
     private containerID: string;
     private quiz: QuizManager;
     private popup: PopUpView;
+    private config: ConfigurationModel;
+    private stats: GameStatsController;
+    private ui: UIController;
 
-    constructor(container: string, quiz: QuizManager) {
+    constructor(
+        container: string,
+        quiz: QuizManager,
+        config: ConfigurationModel,
+        stats: GameStatsController,
+        ui: UIController
+    )  {
         this.view = new WelcomeScreenView(this.handleStart, this.handleInfo, this.handleOptions, container);
-        this.toggleController = new QuestionToggleController(this.view.getStage(), container, () => this.view.getLayer().show());
+        this.config = config;
+        this.stats = stats;
+        this.ui = ui;
+
+        this.toggleController = new QuestionToggleController(
+            this.view.getStage(),
+            container,
+            this.config,
+            this.stats,
+            this.ui,
+            () => this.view.getLayer().show()
+        );
+        
         this.infoView = new InfoCardView(this.view.getStage(), container, this.hideInfo);
         this.popup = new PopUpView(this.view.getLayer(), "Please enter your name\n in the input box below.");
         this.ro = new ResizeObserver(this.handleResize);

--- a/src/models/ConfigurationModel.ts
+++ b/src/models/ConfigurationModel.ts
@@ -1,0 +1,28 @@
+// src/models/ConfigurationModel.ts
+
+/**
+ * ConfigurationModel
+ * - Holds global, user-configurable options such as:
+ *   - maxErrors: how many mistakes are allowed before game over
+ *   - difficulty level: here we simply equate it with maxErrors
+ */
+
+import { OPTION_MAX_ERRORS, OPTION_MIN_ERRORS } from "../utils/constants";
+
+export class ConfigurationModel {
+  private maxErrors: number = 3;
+
+  public getMaxErrors() {
+    return this.maxErrors;
+  }
+
+  public setMaxErrors(value: number) {
+    // clamp 1, 10
+    const v = Math.min(OPTION_MAX_ERRORS, Math.max(OPTION_MIN_ERRORS, value));
+    this.maxErrors = v;
+  }
+
+  public getDifficultyLevel() {
+    return this.maxErrors;
+  }
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -131,6 +131,9 @@ body {
   border: 4px solid var(--theme-border-brown);
   box-sizing: border-box; /* Ensure border doesn't add to width */
   background: #9de3f3;    /* Ocean color fallback */
+  background-image: url('../assets/water-pattern.png'); /* Path to your subtle water pattern image */
+  background-repeat: repeat; /* Repeat the pattern */
+  background-blend-mode: soft-light;   /*overlay soft-light multiply*/
 }
 
 #hud-row {
@@ -304,7 +307,14 @@ body {
   width: clamp(var(--map-min-w), 100%, var(--map-max-w));
   aspect-ratio: var(--map-ratio);
   box-sizing: border-box;
-  background: #9de3f3;
+
+  /* background: #9de3f3; - REMOVE or COMMENT OUT this line */
+  background-color: #9de3f3; /* Base ocean color */
+  background-image: url('../assets/water-pattern.png'); /* Path to your subtle water pattern image */
+  background-repeat: repeat; /* Repeat the pattern */
+  background-blend-mode: soft-light; /* Blend with the base color for a subtle effect */
+
+  border: 1px solid var(--border);
   border: 1px solid var(--border);
   border-radius: 12px;
   min-width: 0;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,6 +1,4 @@
 // src/utils/constants.ts
-export const MAX_ERRORS = 3; //src/views/GameStatsLightbox.ts
-export const GAME_DURATION_MIN = 15;  //src/models/TimerModel.ts
 export const ALL_STATES: string[] = ["Alabama", "Alaska","Arizona", "Arkansas", "California", 
         "Colorado", "Connecticut", "Delaware", "Florida", "Georgia", "Hawaii", "Idaho", 
         "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky", "Louisiana", "Maine", "Maryland", 
@@ -13,3 +11,9 @@ export const ALL_STATES: string[] = ["Alabama", "Alaska","Arizona", "Arkansas", 
 export const STAGE_WIDTH = 2000;
 export const STAGE_HEIGHT = 2000;
 export const CORRECT_POINT_VALUE = 10;
+export const GAME_DURATION_MIN = 15;
+
+// for option min : max
+export const OPTION_MIN_ERRORS = 1;
+export const OPTION_MAX_ERRORS = 10;
+export const BASE_POINTS_PER_QUESTION = 10;

--- a/src/views/FeedbackCardView.ts
+++ b/src/views/FeedbackCardView.ts
@@ -17,7 +17,7 @@ import { CORRECT_POINT_VALUE } from "../utils/constants";
 
 const FILL_CORRECT = '#43A047';
 const STROKE_CORRECT = '#2E7D32';
-const TEXT_CORRECT = 'CORRECT! \n+' + CORRECT_POINT_VALUE + " POINTS!"
+// const TEXT_CORRECT = 'CORRECT! \n+' + CORRECT_POINT_VALUE + " POINTS!"
 
 const FILL_WRONG = '#be1a1aff'
 const STROKE_WRONG = '#841313ff'
@@ -56,7 +56,7 @@ export class FeedbackCardView {
 		const feedbackText = new Konva.Text({
 			width: WIDTH,
 			height: HEIGHT,
-			text: TEXT_CORRECT,
+			text: 'CORRECT!', 
 			fontSize: 36,
 			fontStyle: 'bold',
 			fill: 'white',
@@ -70,10 +70,11 @@ export class FeedbackCardView {
         overlay.getLayer().add(this.feedbackGroup);
     }
 
-    show(correct: boolean, card: QuestionCardView) {
+    show(correct: boolean, card: QuestionCardView, deltaPoints?: number) {
         let text, fill, stroke
         if (correct) {
-            text = TEXT_CORRECT
+            const pts = deltaPoints ?? CORRECT_POINT_VALUE;
+            text = `CORRECT!\n+${pts} POINTS!`;
             fill = FILL_CORRECT
             stroke = STROKE_CORRECT
         } else {

--- a/src/views/GameStatsLightbox.ts
+++ b/src/views/GameStatsLightbox.ts
@@ -27,13 +27,16 @@
         - Styled points text in blue with bold font.
 ==============================*/
 import Konva from "konva";
-import {MAX_ERRORS} from "../utils/constants";
+// import {MAX_ERRORS} from "../utils/constants";
 
 export type GameStatsLightboxOptions = {
   greyCount: number;
   greenCount: number;
   redCount: number;
   points: number;
+
+  maxErrors: number;
+
   onHome?: () => void;
   onOptions?: () => void;
   onHelp?: () => void;
@@ -59,10 +62,15 @@ export default class GameStatsLightbox {
   private labelLeft: Konva.Text;
 
   private resizeObserver: ResizeObserver | null = null;
+  private maxErrors: number;
 
-  constructor(private opts: GameStatsLightboxOptions, width: number = 450, height: number = 110) {
-    const { greyCount, greenCount, redCount, points} = opts;
-
+  constructor(
+    private opts: GameStatsLightboxOptions, 
+    width: number = 450, 
+    height: number = 110
+  ) {
+    const { greyCount, greenCount, redCount, points, maxErrors} = opts;
+    this.maxErrors = maxErrors;
     this.group = new Konva.Group({ listening: true });
 
     this.background = new Konva.Rect({
@@ -102,7 +110,7 @@ export default class GameStatsLightbox {
     // --- top right: ERRORS (red) ---
     this.labelErrors = new Konva.Text({
       x: col2X, y: row1Y,
-      text: `ERRORS: ${redCount}/${MAX_ERRORS}`,
+      text: `ERRORS: ${redCount}/${this.maxErrors}`,
       fontSize: baseFontSize,
       fontFamily: STYLE.font,
       fill: STYLE.red, //red 
@@ -196,8 +204,17 @@ export default class GameStatsLightbox {
   public updateCounts(grey: number, green: number, red: number, points: number): void {
     this.labelScore.text(`SCORE: ${points}`);
     this.labelFound.text(`FOUND: ${green}`);
-    this.labelErrors.text(`ERRORS: ${red}/${MAX_ERRORS}`);
+    this.labelErrors.text(`ERRORS: ${red}/${this.maxErrors}`); 
     this.labelLeft.text(`LEFT: ${grey}`);
+    this.group.getLayer()?.batchDraw();
+  }
+
+  public setMaxErrors(maxErrors: number): void {
+    this.maxErrors = maxErrors;
+    const currentText = this.labelErrors.text();
+    const match = currentText.match(/ERRORS:\s+(\d+)/);
+    const currentRed = match ? parseInt(match[1], 10) : 0;
+    this.labelErrors.text(`ERRORS: ${currentRed}/${this.maxErrors}`);
     this.group.getLayer()?.batchDraw();
   }
 

--- a/src/views/QuestionToggleView.test.ts
+++ b/src/views/QuestionToggleView.test.ts
@@ -6,7 +6,15 @@ describe("question toggle view", () => {
     const mockEl = document.createElement("div");
     mockEl.id = "main-menu-container";
     document.body.appendChild(mockEl);
-    let QTV = new QuestionToggleView(() => {}, (p: keyof Toggles) => {}, () => {}, new Konva.Stage({container: mockEl.id}), "main-menu-container");
+    let QTV = new QuestionToggleView(
+        () => {}, 
+        (p: keyof Toggles) => {}, 
+        () => {}, 
+        new Konva.Stage({container: mockEl.id}), 
+        "main-menu-container",
+        5,
+        () => {}
+    );
 
     it("should generate a layer", () => {
         expect(QTV.getLayer()).toBeDefined();

--- a/src/views/QuestionToggleView.ts
+++ b/src/views/QuestionToggleView.ts
@@ -25,12 +25,18 @@ Related
 
 import Konva from "konva";
 import { getDims, simpleLabelFactory } from "../utils/ViewUtils";
+import { OPTION_MIN_ERRORS, OPTION_MAX_ERRORS } from "../utils/constants";
+
 
 const BUTTON_WIDTH = 300;
 const HEIGHT_SCALAR = 12;
 const CORNER_RADIUS = 10;
 const BOX_BG = "#eee";
 const STROKE_COLOR = "black";
+
+// slider config
+const SLIDER_TRACK_WIDTH = 220;
+const SLIDER_TRACK_HEIGHT = 6;
 
 export interface Toggles {
     [key: string]: boolean
@@ -42,6 +48,16 @@ export class QuestionToggleView {
     private startW: number;
     private id: string;
 
+    // slider state
+    private currentMaxErrors: number;
+    private onMaxErrorsChange?: (value: number) => void;
+
+    // slider nodes (kept for resize)
+    private sliderGroup?: Konva.Group;
+    private sliderTrack?: Konva.Rect;
+    private sliderThumb?: Konva.Circle;
+    private sliderLabel?: Konva.Text;
+
     // backHandler should be a handler for the back button
     // toggleHandler should be a handler for the toggle question buttons
     // saveHandler should be a handler for the save options button
@@ -50,12 +66,24 @@ export class QuestionToggleView {
         toggleHandler: (p: keyof Toggles) => void, 
         saveHandler: () => void, 
         stage: Konva.Stage, 
-        id: string) 
+        id: string,
+        initialMaxErrors: number = OPTION_MAX_ERRORS,
+        onMaxErrorsChange?: (value: number) => void) 
     {
         this.layer = new Konva.Layer({
             visible: false
         });
         this.id = id;
+
+        this.onMaxErrorsChange = onMaxErrorsChange;
+
+        // clamp init [min, max]
+        this.currentMaxErrors = Math.min(
+            OPTION_MAX_ERRORS,
+            Math.max(OPTION_MIN_ERRORS, initialMaxErrors)
+        );
+        this.onMaxErrorsChange = onMaxErrorsChange; 
+        
         let [w, h] = getDims(360, 360, id)
         this.startW = w;
         this.toggleButtonGroup = new Konva.Group();
@@ -65,13 +93,18 @@ export class QuestionToggleView {
         const flowersToggle = simpleLabelFactory(w / 2, 4 * h / HEIGHT_SCALAR, "Toggle Flowers", () => toggleHandler("flowerQuestions"));
         const abbreviationToggle = simpleLabelFactory(w / 2, 5 * h / HEIGHT_SCALAR, "Toggle Abbreviations", () => toggleHandler("abbreviationQuestions"));
         const dateToggle = simpleLabelFactory(w / 2, 6 * h / HEIGHT_SCALAR, "Toggle Creation Dates", () => toggleHandler("dateQuestions"));
-        const saveButton = simpleLabelFactory(w / 2, 7 * h / HEIGHT_SCALAR, "Save", () => saveHandler());
+        
+        // new Slider row
+        const sliderY = (7 * h) / HEIGHT_SCALAR;
+        const sliderGroup = this.createMaxErrorsSlider(w / 2, sliderY);
 
+        const saveButton = simpleLabelFactory(w / 2, 8 * h / HEIGHT_SCALAR, "Save", () => saveHandler());
+        
         const rect = new Konva.Rect({
             x: w / 4,
             y: h / 8,
             width: w / 2,
-            height: 5 * h / 8,
+            height: 6 * h / 8,
             fill: BOX_BG,
             stroke: STROKE_COLOR,
             strokeWidth: 1,
@@ -89,6 +122,7 @@ export class QuestionToggleView {
         this.init(flowersToggle, this.toggleButtonGroup);
         this.init(abbreviationToggle, this.toggleButtonGroup);
         this.init(dateToggle, this.toggleButtonGroup);
+        this.init(sliderGroup, this.toggleButtonGroup);
         this.init(saveButton, this.toggleButtonGroup);
 
         this.layer.add(this.toggleButtonGroup);
@@ -100,6 +134,122 @@ export class QuestionToggleView {
         group.add(node);
     }
 
+    //new slider max error
+    private createMaxErrorsSlider(centerX: number, y: number): Konva.Group {
+        const group = new Konva.Group();
+
+        const label = new Konva.Text({
+            x: centerX - BUTTON_WIDTH / 2,
+            y: y - 18,
+            width: BUTTON_WIDTH,
+            align: "center",
+            text: `Max Mistakes: ${this.currentMaxErrors}`,
+            fontSize: 16,
+            fontFamily: "Arial",
+            fill: "#333"
+        });
+
+        const trackX = centerX - SLIDER_TRACK_WIDTH / 2;
+        const trackY = y + 4;
+
+        const track = new Konva.Rect({
+            x: trackX,
+            y: trackY,
+            width: SLIDER_TRACK_WIDTH,
+            height: SLIDER_TRACK_HEIGHT,
+            fill: "#cccccc",
+            cornerRadius: SLIDER_TRACK_HEIGHT / 2
+        });
+
+        const ratio =
+            (this.currentMaxErrors - OPTION_MIN_ERRORS) /
+            (OPTION_MAX_ERRORS - OPTION_MIN_ERRORS || 1);
+        const thumbX = trackX + ratio * SLIDER_TRACK_WIDTH;
+
+        const thumb = new Konva.Circle({
+            x: thumbX,
+            y: trackY + SLIDER_TRACK_HEIGHT / 2,
+            radius: 8,
+            fill: "#1976d2",
+            stroke: "#0d47a1",
+            strokeWidth: 1,
+            draggable: true,
+
+            dragBoundFunc: (pos) => {
+                if (!this.sliderTrack) return pos;
+
+                const minX = this.sliderTrack.x();
+                const maxX = this.sliderTrack.x() + this.sliderTrack.width();
+                let x = Math.min(maxX, Math.max(minX, pos.x));
+                return {
+                    x,
+                    y: trackY + SLIDER_TRACK_HEIGHT / 2
+                }
+            }
+        });
+
+        const updateValue = (newValue: number) => {
+            const clamped = Math.min(
+                OPTION_MAX_ERRORS,
+                Math.max(OPTION_MIN_ERRORS, newValue)
+            );
+            this.currentMaxErrors = clamped;
+            label.text(`Max Mistakes: ${clamped}`);
+
+            const localRatio =
+                (clamped - OPTION_MIN_ERRORS) /
+                (OPTION_MAX_ERRORS - OPTION_MIN_ERRORS || 1);
+            const newX = trackX + localRatio * SLIDER_TRACK_WIDTH;
+            thumb.x(newX);
+
+            if (this.onMaxErrorsChange) {
+                this.onMaxErrorsChange(clamped);
+            }
+            const layer = label.getLayer() || thumb.getLayer() || track.getLayer();
+            layer?.batchDraw();
+        };
+
+        thumb.on("dragend", () => {
+            const minX = trackX;
+            const maxX = trackX + SLIDER_TRACK_WIDTH;
+            const x = Math.min(maxX, Math.max(minX, thumb.x()));
+            const percent = (x - minX) / (maxX - minX || 1);
+            const raw =
+                OPTION_MIN_ERRORS +
+                percent * (OPTION_MAX_ERRORS - OPTION_MIN_ERRORS);
+            const snapped = Math.round(raw);
+            updateValue(snapped);
+        });
+
+        track.on("click tap", (evt) => {
+            const pos = track.getStage()?.getPointerPosition();
+            if (!pos) return;
+            let x = pos.x;
+            const minX = trackX;
+            const maxX = trackX + SLIDER_TRACK_WIDTH;
+            if (x < minX) x = minX;
+            if (x > maxX) x = maxX;
+
+            const percent = (x - minX) / (maxX - minX || 1);
+            const raw =
+                OPTION_MIN_ERRORS +
+                percent * (OPTION_MAX_ERRORS - OPTION_MIN_ERRORS);
+            const snapped = Math.round(raw);
+            updateValue(snapped);
+        });
+
+        group.add(label);
+        group.add(track);
+        group.add(thumb);
+
+        this.sliderGroup = group;
+        this.sliderTrack = track;
+        this.sliderThumb = thumb;
+        this.sliderLabel = label;
+
+        return group;
+    }
+
     show(): void {
         this.layer.visible(true);
         this.layer.draw();
@@ -109,12 +259,73 @@ export class QuestionToggleView {
         this.layer.visible(false);
         this.layer.draw();
     }
+public resize(): void {
+    const [w] = getDims(360, 360, this.id);
 
-    public resize(): void {
+    this.layer.getChildren().forEach((group) => {
+        if (group instanceof Konva.Group) {
+            group.getChildren().forEach(subnode => {
+                if (subnode === this.sliderGroup) return;
+
+                if (subnode instanceof Konva.Group) {
+                    subnode.getChildren().forEach(node => {
+                        node.x(Math.max(10, w / 2));
+                    });
+                } else if (
+                    subnode instanceof Konva.Rect &&
+                    subnode.getAttr("centerOffset")
+                ) {
+                    subnode.x(
+                        Math.max(10, w / 2 - subnode.getAttr("centerOffset"))
+                    );
+                }
+            });
+        }
+    });
+
+    if (this.sliderTrack && this.sliderThumb && this.sliderLabel) {
+        const centerX = w / 2;
+
+        const labelY = this.sliderLabel.y();
+        const trackY = this.sliderTrack.y();
+
+        this.sliderLabel.x(centerX - BUTTON_WIDTH / 2);
+        this.sliderLabel.y(labelY);
+        this.sliderLabel.width(BUTTON_WIDTH);
+
+        const trackX = centerX - SLIDER_TRACK_WIDTH / 2;
+        this.sliderTrack.x(trackX);
+
+        const ratio =
+            (this.currentMaxErrors - OPTION_MIN_ERRORS) /
+            (OPTION_MAX_ERRORS - OPTION_MIN_ERRORS || 1);
+        const thumbX = trackX + ratio * SLIDER_TRACK_WIDTH;
+
+        this.sliderThumb.x(thumbX);
+        this.sliderThumb.y(trackY + SLIDER_TRACK_HEIGHT / 2);
+
+        this.sliderThumb.dragBoundFunc((pos) => {
+            const minX = this.sliderTrack!.x();
+            const maxX = this.sliderTrack!.x() + this.sliderTrack!.width();
+            let x = Math.min(maxX, Math.max(minX, pos.x));
+            return {
+                x,
+                y: this.sliderTrack!.y() + this.sliderTrack!.height() / 2,
+            };
+        });
+    }
+
+    this.layer.draw();
+}
+
+
+/*     public resize(): void {
         let [w, h] = getDims(360, 360, this.id);
+
         this.layer.getChildren().forEach((group) => {
             if (group instanceof Konva.Group) {
                 group.getChildren().forEach(subnode => {
+                    if (subnode === this.sliderGroup) return;
                     if (subnode instanceof Konva.Group) {
                         subnode.getChildren().forEach(node => {
                             node.x(Math.max(10, w / 2 ));
@@ -126,8 +337,43 @@ export class QuestionToggleView {
                 });
             }
         });
-    }
+        
+        if (this.sliderGroup && this.sliderTrack && this.sliderThumb && this.sliderLabel) {
+            const centerX = w / 2;
+            const sliderY = (7 * h) / HEIGHT_SCALAR;
 
+            this.sliderLabel.x(centerX - BUTTON_WIDTH / 2);
+            this.sliderLabel.y(sliderY - 18);
+            this.sliderLabel.width(BUTTON_WIDTH);
+
+            const trackX = centerX - SLIDER_TRACK_WIDTH / 2;
+            const trackY = sliderY + 4;
+
+            this.sliderTrack.x(trackX);
+            this.sliderTrack.y(trackY);
+            this.sliderTrack.width(SLIDER_TRACK_WIDTH);
+            this.sliderTrack.height(SLIDER_TRACK_HEIGHT);
+
+            const ratio =
+                (this.currentMaxErrors - OPTION_MIN_ERRORS) /
+                (OPTION_MAX_ERRORS - OPTION_MIN_ERRORS || 1);
+            const thumbX = trackX + ratio * SLIDER_TRACK_WIDTH;
+
+            this.sliderThumb.x(thumbX);
+            this.sliderThumb.y(trackY + SLIDER_TRACK_HEIGHT / 2);
+                this.sliderThumb.dragBoundFunc((pos) => {
+                const minX = this.sliderTrack!.x();
+                const maxX = this.sliderTrack!.x() + this.sliderTrack!.width();
+                let x = Math.min(maxX, Math.max(minX, pos.x));
+                return {
+                    x,
+                    y: this.sliderTrack!.y() + this.sliderTrack!.height() / 2,
+                };
+            });
+        }
+        this.layer.draw();
+    }
+ */
     getLayer(): Konva.Layer {
         return this.layer;
     }

--- a/src/views/RoadTripDashboardView.ts
+++ b/src/views/RoadTripDashboardView.ts
@@ -27,7 +27,7 @@
         - Implemented ResizeObserver for responsive canvas scaling.
 ==============================*/
 import Konva from 'konva';
-import { MAX_ERRORS } from "../utils/constants";
+//import { MAX_ERRORS } from "../utils/constants";
 
 // BG PNG for road
 import bgUrl from '../assets/us-roadtrip-panorama.png'; 
@@ -109,7 +109,7 @@ export class RoadTripDashboardView {
 
     // Game State
     private totalStarsGoal: number;
-    private maxHits = MAX_ERRORS;
+    private maxHits: number;   
     private starCount = 0;
     private hitCount = 0;
     private progress = 0; 
@@ -135,9 +135,10 @@ export class RoadTripDashboardView {
     private starLabel: Konva.Text | null = null;
     private damageLabel: Konva.Text | null = null;
 
-    constructor(containerId: string, totalStarsGoal: number, onCarBroken?: () => void) {
+    constructor(containerId: string, maxHits: number, onCarBroken?: () => void) {
         this.containerId = containerId;
-        this.totalStarsGoal = totalStarsGoal > 10 ? totalStarsGoal : 50;
+        this.totalStarsGoal = maxHits > 10 ? maxHits : 50;
+        this.maxHits = maxHits;
         this.onCarBrokenCallback = onCarBroken || null;
     }
 
@@ -677,6 +678,14 @@ export class RoadTripDashboardView {
         if (this.starLabel) this.starLabel.text(`${CONFIG.EMOJI.POINTS} ${this.starCount}`);
         if (this.damageLabel) this.damageLabel.text(`${CONFIG.EMOJI.OBSTACLE} ${this.hitCount}/${this.maxHits}`);
     }
+    
+    public setMaxHits(maxHits: number): void {
+        this.maxHits = maxHits;
+        if (this.damageLabel) {
+            this.damageLabel.text(`${CONFIG.EMOJI.OBSTACLE} ${this.hitCount}/${this.maxHits}`);
+            this.hudLayer?.batchDraw();
+        }
+    }
 
     private spawnSmoke(): void {
         if (!this.carGroup || !this.entityLayer) return;
@@ -799,5 +808,10 @@ export class RoadTripDashboardView {
         if (type === 'plane') this.triggerPlaneFlyover(true);
         if (type === 'star') this.spawnItemOnRoad('star');
         if (type === 'hit') this.spawnItemOnRoad('obstacle');
+    }
+
+    public updateMaxHits(maxHits: number): void {
+        this.maxHits = maxHits;
+        this.updateHud();
     }
 }

--- a/src/views/WelcomeScreenView.ts
+++ b/src/views/WelcomeScreenView.ts
@@ -58,11 +58,21 @@ export class WelcomeScreenView {
         });
         let titleText = new Konva.Text({
             text: " WELCOME to the \n U.S. Geography Game!",
-            fill: 'black',
-            fontSize: 40,
+            fill: 'white',
+            fontSize: 60,
             fontStyle: "bold",
             padding: 4,
-            align: "center"      
+            align: "center",
+            // --- (Border/Stroke) ---
+            stroke: 'rgba(255, 255, 255, 0.5)',
+            strokeWidth: 1,
+
+            // --- (Shadow) ---
+            shadowColor: 'black', 
+            shadowBlur: 5,
+            shadowOffsetX: 4, 
+            shadowOffsetY: 4,
+            shadowOpacity: 0.8
         });
         titleText.offsetX(titleText.width() / 2);
         this.titleGroup.add(titleText);
@@ -78,13 +88,14 @@ export class WelcomeScreenView {
             this.layer.batchDraw();
         });
 
-        const startLabel = simpleLabelFactory(w / 2, h / 4 + 110, "Start Game", startHandler);
-        const infoLabel = simpleLabelFactory(w / 2, h / 4 + 310, "How To Play", infoHandler);
-        const optionsLabel = simpleLabelFactory(w / 2, h / 4 + 410, "Options", optionsHandler);
+        const startLabel = simpleLabelFactory(w / 2, h / 4 + 270, "Start Game", startHandler);
+        const infoLabel = simpleLabelFactory(w / 2, h / 4 + 390, "How To Play", infoHandler);
+        const optionsLabel = simpleLabelFactory(w / 2, h / 4 + 450, "Options", optionsHandler);
 
         this.toggleButtonGroup = new Konva.Group();
 
         let menuEl = document.getElementById(id);
+
         const textBox = document.createElement("textarea");
         textBox.id = "nameInput";
         textBox.style.top = h / 4 + 210 + "px";


### PR DESCRIPTION
Options: Max Mistakes Slider

Added a “Max Mistakes” slider in QuestionToggleView:

> Slider range is [OPTION_MIN_ERRORS, OPTION_MAX_ERRORS], draggable and clickable.
> Value snaps to integers and updates a centered label (Max Mistakes: N).

The slider’s value is wired to ConfigurationModel through QuestionToggleController:

> Initial slider position uses config.getMaxErrors().
> Changes propagate back via an onMaxErrorsChange callback.

Configuration & Scoring & HUD

GameStatsController now owns the scoring logic:

1. New helper computeDeltaPointsForCorrect() uses:

> const difficulty = config.getDifficultyLevel();
> const factor = Math.pow(11 - difficulty, 2);
> const deltaPoints = factor * BASE_POINTS_PER_QUESTION;


2. onCorrect() adds deltaPoints and returns it to callers.

GameStatsLightbox:

> New maxErrors option and member field.
> 
> Errors label now shows ERRORS: redCount/maxErrors.
> 
> Added setMaxErrors(maxErrors: number) for live updates.

GameStatsController.updateMaxErrors(maxErrors):

Updates ConfigurationModel and forwards the value to the lightbox.

isFinished() now checks red >= config.getMaxErrors() for failure, and grey === 0 for success.

RoadTrip HUD Integration

UIController.updateMaxErrors() forwards maxErrors to RoadTripDashboardView.setMaxHits().

Ensures Options slider → config → GameStats → RoadTrip HUD all use the same max mistake value.

Feedback Card: Show Real Points

FeedbackCardView.show() signature extended to support a deltaPoints parameter.

Correct popup text now displays +{deltaPoints} POINTS! instead of a fixed constant.

UIController.answerResponse():

> Calls statsController.onCorrect() and receives the per-question delta.
> 
> Passes deltaPoints into FeedbackCardView.show(correct, card, deltaPoints) so the popup and stats stay in sync.
> 
> Question Card & Options Resize Fixes

QuestionToggleView.resize():

> Keeps all buttons centered (as before).
> 
> Recalculates slider label position, track position, and thumb position based on the current stage width/height.
> 
> Re-applies a dragBoundFunc so the thumb remains constrained to the track after resize.

UIController.openQuestion():

Before resizing the card, it now reads the stage container’s getBoundingClientRect() and updates stage.width/height to the real DOM size.

Then calls card.resize() so the question card respects the current window size when the game starts or resumes.

This prevents the “first question after Start Game uses old size” bug.

Minor Cleanups

WelcomeScreenController now receives a ConfigurationModel instance and passes it into QuestionToggleController.

GameStatsLightbox and HUD wiring now consistently use maxErrors from config rather than a hard-coded constant.